### PR TITLE
Update README to reflect for Django >=1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ add `wagtailgmaps` and `overextends` to your `settings.py` before any wagtail ap
 ...
 ```
 
+For Django 1.9+ you must add `overextends` to the `builtins` option of your `TEMPLATES` setting:
+
+```
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'builtins': ['overextends.templatetags.overextends_tags'],
+        }
+    },
+]
+```
+
 Add a couple of necessary constants in your `settings.py` file:
 
 ```


### PR DESCRIPTION
Added install step required for overextends to work with Django >=1.9. `{% overextends %}` is no longer available in templates with modifying the `TEMPLATES['OPTIONS']['builtins']` settings.
